### PR TITLE
Revert "Seclorum tweaks: Makefile"

### DIFF
--- a/-Oirs
+++ b/-Oirs
@@ -1,0 +1,4 @@
+.asm_check:	libsrc/mia.s asminc/loci.inc /home/xahmol/cc65/asminc/errno.inc
+
+libsrc/mia.s asminc/loci.inc /home/xahmol/cc65/asminc/errno.inc:
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-BUILD/locitest.tap
-
 # Prerequisites
 *.d
 

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,12 @@
 # Thanks to Iss for pointers for this Makefile:
 # https://forum.defence-force.org/viewtopic.php?p=25411#p25411
 
-## Paths - xahmols' defaults, but can be overridden by passing in the relevant ENV var
-#
-# Path to OSDK install. pass in, i.e. "OSDK=/osdk make" to override this default
+## Paths
+# Path tp OSDK install. Edit for local dir
 # Installation instructions for Linux: #https://forum.defence-force.org/viewtopic.php?p=25396#p25396
-# for MacOS: set up in WINE and pass in OSDK=~/.wine/drive_c/OSDK/
-OSDK ?= /home/xahmol/OSDK-build/pc/tools/osdk/main/osdk-linux/bin/
-# Emulator path: edit for location of emulator to use - pass in EMUL_DIR= to override
-EMUL_DIR ?= /home/xahmol/oricutron/
+OSDK := /home/xahmol/OSDK-build/pc/tools/osdk/main/osdk-linux/bin/
+# Emulator path: edit for location of emulator to use
+EMUL_DIR := /home/xahmol/oricutron/
 # Makefile full path
 mkfile_path := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -58,9 +56,6 @@ CC        = $(CC65_HOME)/bin/cl65
 AR        = $(CC65_HOME)/bin/ar65
 CP        = cp -f
 
-# the location of the shared machine .lib re-distributables from cc65, pass-in override
-CC65_HOME_SHARE ?= $(CC65_HOME)/share/cc65
-
 ## Compiler and linker flags
 CC65_TARGET = atmos
 CFLAGS  = -t $(CC65_TARGET) -Oirs --debug-info -I include --asm-include-dir asminc -I asminc
@@ -90,10 +85,9 @@ else
 	$(CC) -c $(CFLAGS) -o $@ $<
 endif
 
-# Build archive library including atmos.lib
+# Buold librarry
 $(LIBRARY): $(LSOURCES:.c=.o) $(LASOURCES:.s=.o)
-	mkdir -p lib/
-	$(CP) $(CC65_HOME_SHARE)/lib/$(CC65_TARGET).lib $(LIBRARY)
+	$(CP) $(CC65_HOME)/lib/$(CC65_TARGET).lib $(LIBRARY)
 	$(AR) a $(LIBRARY) $(LSOURCES:.c=.o) $(LASOURCES:.s=.o)
 
 # Link compiled objects 


### PR DESCRIPTION
Reverts xahmol/locitest#1

Does not yet work on my machine, probably due to non standard CC65 install as I wanted to compile from latest CC65 source instead of doing apt install.

On my machine there is no share/cc65 dir under the CC65 install.

Will look at it later, but will now revert.